### PR TITLE
BLD: Fix build by removing -march=native flag on unix

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,10 @@ source:
   sha256: 64b6625f987ea5af7d602b3c256d611f87cc809766734e62641e45410184a435
 
 build:
-  number: 0
+  number: 1
   skip: true   # [py>=40 or py<36]
+  script_env:
+    - BUILD_WHEEL=1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -32,6 +34,7 @@ test:
     - {{ name }}
   commands:
     - pip check
+    - python -c "from polyagamma import random_polyagamma;print(random_polyagamma())"
   requires:
     - pip
 


### PR DESCRIPTION

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

closes #1 

This PR uses the BUILD_WHEEL environmental variable to deactivate the `-march=native` compiler flag causing the crash reported in #1. This flag will be removed entirely in a newer version of the package.
